### PR TITLE
Fix chunk removal check

### DIFF
--- a/Source/SimpleChunkSystem/Public/System/ChunkSystem.h
+++ b/Source/SimpleChunkSystem/Public/System/ChunkSystem.h
@@ -324,11 +324,11 @@ public:
 			const FIntPoint& ChunkPoint = ChunkToGrid.Key;
 			const TSet<FIntPoint>& GridPoints = ChunkToGrid.Value;
 
-			if (Chunks.Contains(ChunkPoint))
-			{
-				SCHUNK_LOG(LogSChunkSystemLocal, Warning, TEXT("Chunk does not exist at %s"), *ChunkPoint.ToString());
-				continue;
-			}
+                        if (!Chunks.Contains(ChunkPoint))
+                        {
+                                SCHUNK_LOG(LogSChunkSystemLocal, Warning, TEXT("Chunk does not exist at %s"), *ChunkPoint.ToString());
+                                continue;
+                        }
 
 			for (const FIntPoint& Point : GridPoints)
 			{


### PR DESCRIPTION
## Summary
- fix logic for removing channels by grid when chunk doesn't exist

## Testing
- `g++ -std=c++20 -fsyntax-only Source/SimpleChunkSystem/Public/System/ChunkSystem.h` *(fails: CoreMinimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689650f7d1788325aa94e21730fdadc1